### PR TITLE
test(frontend): cover toastManager + queueAttributesHandler

### DIFF
--- a/test/queueAttributesHandler.test.js
+++ b/test/queueAttributesHandler.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { QueueAttributesHandler } from '../static/modules/queueAttributesHandler.js';
+
+describe('QueueAttributesHandler', () => {
+  let handler;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="queueAttributes"></div>';
+    handler = new QueueAttributesHandler();
+  });
+
+  describe('display', () => {
+    it('should render a table row for each important attribute when present', () => {
+      handler.display({
+        ApproximateNumberOfMessages: '42',
+        ApproximateNumberOfMessagesNotVisible: '3',
+        VisibilityTimeout: '30',
+      });
+
+      const rows = document.querySelectorAll('#queueAttributes table tr');
+      expect(rows.length).toBe(3);
+
+      const labels = Array.from(document.querySelectorAll('.attr-label')).map((el) => el.textContent);
+      expect(labels).toEqual(['Messages', 'Not Visible', 'Visibility (sec)']);
+
+      const values = Array.from(document.querySelectorAll('.attr-value')).map((el) => el.textContent);
+      expect(values).toEqual(['42', '3', '30']);
+    });
+
+    it('should skip attributes that are not in the important whitelist', () => {
+      handler.display({
+        ApproximateNumberOfMessages: '5',
+        QueueArn: 'arn:aws:sqs:us-east-1:123:test-queue',
+        RedrivePolicy: '{"deadLetterTargetArn":"..."}',
+      });
+
+      const rows = document.querySelectorAll('#queueAttributes table tr');
+      expect(rows.length).toBe(1);
+      expect(document.querySelector('.attr-label').textContent).toBe('Messages');
+    });
+
+    it('should clear previous content when called again', () => {
+      handler.display({ ApproximateNumberOfMessages: '5' });
+      handler.display({ VisibilityTimeout: '60' });
+
+      const rows = document.querySelectorAll('#queueAttributes table tr');
+      expect(rows.length).toBe(1);
+      expect(document.querySelector('.attr-label').textContent).toBe('Visibility (sec)');
+    });
+
+    it('should clear content and render nothing when attributes is null', () => {
+      handler.setContent('<table><tr><td>stale</td></tr></table>');
+      handler.display(null);
+
+      expect(document.getElementById('queueAttributes').innerHTML).toBe('');
+    });
+
+    it('should clear content and render nothing when attributes is undefined', () => {
+      handler.setContent('<table><tr><td>stale</td></tr></table>');
+      handler.display(undefined);
+
+      expect(document.getElementById('queueAttributes').innerHTML).toBe('');
+    });
+
+    it('should render an empty table when attributes object has no important keys', () => {
+      handler.display({ QueueArn: 'arn:aws:sqs:test', CreatedTimestamp: '1640995200' });
+
+      const table = document.querySelector('#queueAttributes table');
+      expect(table).not.toBeNull();
+      expect(table.querySelectorAll('tr').length).toBe(0);
+    });
+  });
+
+  describe('createAttributeRow', () => {
+    it('should produce a row with labelled label and value cells', () => {
+      const row = handler.createAttributeRow('Messages', '42');
+
+      expect(row.tagName).toBe('TR');
+      const cells = row.querySelectorAll('td');
+      expect(cells.length).toBe(2);
+      expect(cells[0].className).toBe('attr-label');
+      expect(cells[0].textContent).toBe('Messages');
+      expect(cells[1].className).toBe('attr-value');
+      expect(cells[1].textContent).toBe('42');
+    });
+
+    it('should use textContent (not innerHTML) so values are inserted safely', () => {
+      // The handler sets `valueCell.textContent = value`, which is the safe
+      // path. We can't directly assert the encoded innerHTML here because
+      // happy-dom does not HTML-encode on serialization, so we verify the
+      // structural property: the cell holds the raw string as text and has
+      // no parsed child elements.
+      const row = handler.createAttributeRow('Label', '<script>alert(1)</script>');
+
+      const valueCell = row.querySelector('.attr-value');
+      expect(valueCell.children.length).toBe(0);
+      expect(valueCell.textContent).toBe('<script>alert(1)</script>');
+    });
+  });
+});

--- a/test/toastManager.test.js
+++ b/test/toastManager.test.js
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { ToastManager } from '../static/modules/toastManager.js';
+
+describe('ToastManager', () => {
+  let toast;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.useFakeTimers();
+    toast = new ToastManager();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('init', () => {
+    it('should create a toast container with accessibility attributes on construction', () => {
+      const container = document.getElementById('toast-container');
+      expect(container).not.toBeNull();
+      expect(container.getAttribute('aria-live')).toBe('polite');
+      expect(container.getAttribute('aria-atomic')).toBe('true');
+    });
+  });
+
+  describe('show', () => {
+    it('should render a toast with the given message and type', () => {
+      toast.show('Saved', 'success');
+
+      const el = document.querySelector('.toast');
+      expect(el).not.toBeNull();
+      expect(el.classList.contains('toast-success')).toBe(true);
+      expect(el.querySelector('.toast-message').textContent).toBe('Saved');
+    });
+
+    it('should pass message through escapeHtml so escaping happens before injection', () => {
+      // happy-dom does not implement HTML escaping on innerHTML serialization,
+      // so we verify the call boundary by spying rather than asserting on output.
+      // In a real browser, escapeHtml's textContent->innerHTML round-trip
+      // would HTML-encode the dangerous characters.
+      const spy = vi.spyOn(toast, 'escapeHtml');
+      toast.show('<img src=x onerror=alert(1)>', 'info');
+
+      expect(spy).toHaveBeenCalledWith('<img src=x onerror=alert(1)>');
+    });
+
+    it('should auto-dismiss the toast after the configured duration', () => {
+      toast.show('temp', 'info', 1000);
+      expect(document.querySelectorAll('.toast').length).toBe(1);
+
+      vi.advanceTimersByTime(1000);
+      // remove() schedules a 300ms fade-out before DOM removal
+      vi.advanceTimersByTime(300);
+
+      expect(document.querySelectorAll('.toast').length).toBe(0);
+    });
+
+    it('should leave the toast permanent when duration is 0', () => {
+      toast.show('persistent', 'info', 0);
+
+      vi.advanceTimersByTime(60_000);
+      expect(document.querySelectorAll('.toast').length).toBe(1);
+    });
+
+    it('should remove the toast when its close button is clicked', () => {
+      toast.show('closable', 'info', 0);
+
+      document.querySelector('.toast-close').click();
+      vi.advanceTimersByTime(300);
+
+      expect(document.querySelectorAll('.toast').length).toBe(0);
+    });
+
+    it('should default type to info when not specified', () => {
+      toast.show('hello');
+
+      const el = document.querySelector('.toast');
+      expect(el.classList.contains('toast-info')).toBe(true);
+    });
+
+    it('should return a unique id per call so toasts can be removed individually', () => {
+      const idA = toast.show('a');
+      const idB = toast.show('b');
+
+      expect(idA).not.toBe(idB);
+    });
+  });
+
+  describe('typed shortcuts', () => {
+    it('should render a success toast with the success class', () => {
+      toast.success('Done');
+      expect(document.querySelector('.toast-success')).not.toBeNull();
+    });
+
+    it('should render an error toast with the error class', () => {
+      toast.error('Failed');
+      expect(document.querySelector('.toast-error')).not.toBeNull();
+    });
+
+    it('should render a warning toast with the warning class', () => {
+      toast.warning('Careful');
+      expect(document.querySelector('.toast-warning')).not.toBeNull();
+    });
+
+    it('should render an info toast with the info class', () => {
+      toast.info('FYI');
+      expect(document.querySelector('.toast-info')).not.toBeNull();
+    });
+  });
+
+  describe('confirm', () => {
+    it('should render a confirm toast with both action buttons', () => {
+      toast.confirm('Are you sure?', () => {});
+
+      const confirmToast = document.querySelector('.toast-confirm');
+      expect(confirmToast).not.toBeNull();
+      expect(confirmToast.getAttribute('role')).toBe('alertdialog');
+      expect(confirmToast.querySelector('.toast-btn-confirm')).not.toBeNull();
+      expect(confirmToast.querySelector('.toast-btn-cancel')).not.toBeNull();
+    });
+
+    it('should invoke onConfirm and remove the toast when confirm is clicked', () => {
+      const onConfirm = vi.fn();
+      const onCancel = vi.fn();
+
+      toast.confirm('Delete this?', onConfirm, onCancel);
+      document.querySelector('.toast-btn-confirm').click();
+      vi.advanceTimersByTime(300);
+
+      expect(onConfirm).toHaveBeenCalledOnce();
+      expect(onCancel).not.toHaveBeenCalled();
+      expect(document.querySelector('.toast-confirm')).toBeNull();
+    });
+
+    it('should invoke onCancel and remove the toast when cancel is clicked', () => {
+      const onConfirm = vi.fn();
+      const onCancel = vi.fn();
+
+      toast.confirm('Delete this?', onConfirm, onCancel);
+      document.querySelector('.toast-btn-cancel').click();
+      vi.advanceTimersByTime(300);
+
+      expect(onCancel).toHaveBeenCalledOnce();
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(document.querySelector('.toast-confirm')).toBeNull();
+    });
+
+    it('should not throw when onCancel is omitted and cancel is clicked', () => {
+      toast.confirm('msg', () => {});
+
+      expect(() => {
+        document.querySelector('.toast-btn-cancel').click();
+        vi.advanceTimersByTime(300);
+      }).not.toThrow();
+    });
+
+    it('should pass confirm message through escapeHtml before injection', () => {
+      const spy = vi.spyOn(toast, 'escapeHtml');
+      toast.confirm('<b>delete?</b>', () => {});
+
+      expect(spy).toHaveBeenCalledWith('<b>delete?</b>');
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove the targeted toast and leave others intact', () => {
+      const idA = toast.show('a', 'info', 0);
+      toast.show('b', 'info', 0);
+
+      toast.remove(idA);
+      vi.advanceTimersByTime(300);
+
+      const remaining = document.querySelectorAll('.toast');
+      expect(remaining.length).toBe(1);
+      expect(remaining[0].querySelector('.toast-message').textContent).toBe('b');
+    });
+
+    it('should be a no-op when the id does not match any toast', () => {
+      toast.show('a', 'info', 0);
+
+      expect(() => toast.remove(9999)).not.toThrow();
+      vi.advanceTimersByTime(300);
+      expect(document.querySelectorAll('.toast').length).toBe(1);
+    });
+
+    it('should clear the auto-dismiss timer when removed manually', () => {
+      const id = toast.show('temp', 'info', 1000);
+
+      toast.remove(id);
+      vi.advanceTimersByTime(300);
+      // The original auto-dismiss timeout should not double-fire and crash
+      vi.advanceTimersByTime(2000);
+
+      expect(document.querySelectorAll('.toast').length).toBe(0);
+    });
+  });
+
+  describe('clearAll', () => {
+    it('should remove every toast immediately', () => {
+      toast.show('a', 'info', 0);
+      toast.show('b', 'info', 0);
+      toast.show('c', 'info', 0);
+
+      toast.clearAll();
+
+      expect(document.querySelectorAll('.toast').length).toBe(0);
+    });
+
+    it('should reset the toast list so subsequent shows start fresh', () => {
+      toast.show('a', 'info', 0);
+      toast.clearAll();
+      toast.show('b', 'info', 0);
+
+      expect(document.querySelectorAll('.toast').length).toBe(1);
+    });
+  });
+
+  describe('getIcon', () => {
+    it('should return the matching icon for known types', () => {
+      expect(toast.getIcon('success')).toBe('✓');
+      expect(toast.getIcon('error')).toBe('✕');
+      expect(toast.getIcon('warning')).toBe('⚠');
+      expect(toast.getIcon('info')).toBe('ℹ');
+    });
+
+    it('should fall back to the info icon for an unknown type', () => {
+      expect(toast.getIcon('mystery')).toBe('ℹ');
+    });
+  });
+
+  describe('escapeHtml', () => {
+    it('should return a string for any string input without throwing', () => {
+      // happy-dom's innerHTML serialization does not HTML-encode like real
+      // browsers do, so we cannot assert on the encoded form here. The
+      // textContent->innerHTML round-trip is the standard browser-side
+      // escape pattern; this test guards the function shape only.
+      expect(typeof toast.escapeHtml('<script>x</script>')).toBe('string');
+      expect(typeof toast.escapeHtml('')).toBe('string');
+      expect(typeof toast.escapeHtml('plain text')).toBe('string');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
First slice of #10. Adds unit tests for two previously-untested frontend modules.

Refs #10, #16

## Type
- [x] Tests

## Coverage delta
| Module | Stmts before | Stmts after |
|---|---|---|
| \`toastManager.js\` | 43.08% | **99.18%** |
| \`queueAttributesHandler.js\` | 28.30% | **100.00%** |
| **Frontend total** | **72.64%** | **76.49%** |

Frontend tests: 413 → 446 (+33).

## Test focus
- **\`toastManager\`** — toast lifecycle (show/auto-dismiss/permanent), typed shortcuts (success/error/warning/info), confirm flow with onConfirm + onCancel callbacks, manual remove, clearAll, getIcon fallbacks. Uses \`vi.useFakeTimers\` to control \`requestAnimationFrame\` and \`setTimeout\`-based animations.
- **\`queueAttributesHandler\`** — important-attribute filtering (only the 5 whitelisted keys render), null/undefined safety, content-clearing on re-display, and the row-construction primitive.

## Note on happy-dom
\`toastManager.escapeHtml\` uses the standard textContent→innerHTML round-trip. Real browsers HTML-encode on serialization; happy-dom does not. The XSS-prevention assertions therefore guard the call boundary (via \`vi.spyOn(toast, 'escapeHtml')\`) rather than asserting on the encoded output, with comments documenting why. In production browsers, the existing implementation correctly escapes.

## Testing
- [x] \`npx vitest run test/toastManager.test.js test/queueAttributesHandler.test.js\` — 33/33 pass
- [x] \`npm test\` — 446/446 pass
- [x] \`npm run test:coverage\` — confirms gains above
- [x] No source modules touched

## Checklist
- [x] No secrets in code
- [x] Tests follow Arrange-Act-Assert with descriptive \`should ... when ...\` names
- [x] Fake timers used to keep animation-driven assertions deterministic