### PR TITLE
chore(lint): unblock master CI (ESLint warnings + golangci-lint v2)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,29 @@
+version: '2'
 linters:
   enable:
-    - errcheck
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
     - misspell
-
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-rules:
-    # Exclude errcheck for test files where we intentionally don't check certain errors
-    - path: _test\.go
-      linters:
-        - errcheck
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/demo/demo.go
+++ b/internal/demo/demo.go
@@ -276,10 +276,11 @@ func (d *DemoSQSClient) GetQueueAttributes(ctx context.Context, params *sqs.GetQ
 	}
 
 	// Add DLQ-specific attributes for the deadletter queue
-	if queueName == "demo-deadletter-queue" {
+	switch queueName {
+	case "demo-deadletter-queue":
 		// RedriveAllowPolicy indicates this IS a DLQ that can receive messages from source queues
 		attributes["RedriveAllowPolicy"] = `{"redrivePermission":"allowAll"}`
-	} else if queueName == "demo-orders-queue" || queueName == "demo-payments-queue" || queueName == "demo-notifications-queue" {
+	case "demo-orders-queue", "demo-payments-queue", "demo-notifications-queue":
 		// RedrivePolicy indicates these queues send failed messages TO the DLQ
 		attributes["RedrivePolicy"] = `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:123456789012:demo-deadletter-queue","maxReceiveCount":"3"}`
 	}

--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -3,6 +3,7 @@
  * Tests for pagination controls and navigation functionality
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
 import { Pagination } from '../static/modules/pagination.js';
 
 describe('Pagination Component', () => {

--- a/test/themeManager.test.js
+++ b/test/themeManager.test.js
@@ -3,6 +3,7 @@
  * Tests for theme switching and persistence
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
 import ThemeManager from '../static/modules/themeManager.js';
 
 describe('ThemeManager', () => {

--- a/test/webSocketManager.test.js
+++ b/test/webSocketManager.test.js
@@ -3,6 +3,7 @@
  * Tests for WebSocket connection management and message handling
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
 import { WebSocketManager } from '../static/modules/webSocketManager.js';
 
 describe('WebSocketManager', () => {


### PR DESCRIPTION
## Summary
Master CI has been failing for ~a month due to two unrelated lint issues. This PR fixes both so the green-build floor is restored before more PRs land.

## Type
- [x] Maintenance

## Changes

### Commit 1: \`chore(lint): fix import/order warnings in three test files\`
ESLint config sets \`--max-warnings 0\`. Three test files had \`import/order\` warnings (missing empty line between external and local imports). Auto-fixed with \`eslint --fix\`.

Files: \`test/pagination.test.js\`, \`test/themeManager.test.js\`, \`test/webSocketManager.test.js\`

### Commit 2: \`chore(lint): migrate .golangci.yml to v2 format\`
\`golangci-lint-action@v6\` with \`version: latest\` pulls v2, which rejects the existing v1 config:
\`\`\`
Error: can't load config: unsupported version of the configuration: ""
\`\`\`

Ran \`golangci-lint migrate\` to produce a v2 schema. The migration:
- Adds \`version: "2"\` and uses default linter set (preserves errcheck/govet/ineffassign/staticcheck/unused)
- Moves the test-file errcheck exclusion under \`linters.exclusions.rules\`
- Adds standard exclusion presets

Surfaced one new \`staticcheck QF1003\` warning in \`internal/demo/demo.go\` — refactored the relevant if/else-if chain into a tagged switch.

## Testing
- [x] \`npx eslint --max-warnings 0 'static/**/*.js' 'test/**/*.js'\` — 0 errors, 0 warnings
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./...\` — all packages pass
- [x] \`npm test\` — 446/446 passing

## Why this matters for the demo
Master's CI badge has been red since the last security commit on 2026-03-30. Fixing it ensures #17 (RetryMessage tests) and #18 (toast tests) land cleanly without false-negative CI noise.

Refs #16