### PR TITLE
feat(server): port-collision fallback for friction-free demo boot

### DIFF
--- a/cmd/sqs-ui/listen.go
+++ b/cmd/sqs-ui/listen.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
+
+// listenWithFallback binds a TCP listener to the requested port. When strict is
+// false and the requested port cannot be bound (typically because it's already
+// in use), it tries the next `retries` ports before giving up. When strict is
+// true (the user explicitly set PORT), it fails immediately rather than
+// silently using a different port.
+//
+// Returns the bound listener and the port number actually in use, which is
+// read back from the listener after binding so that ":0" requests reflect the
+// kernel-assigned ephemeral port.
+func listenWithFallback(portStr string, retries int, strict bool) (net.Listener, int, error) {
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port < 0 || port > 65535 {
+		return nil, 0, fmt.Errorf("invalid port %q", portStr)
+	}
+
+	var lastErr error
+	for i := 0; i <= retries; i++ {
+		candidate := port + i
+		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", candidate))
+		if err == nil {
+			actual := candidate
+			if tcpAddr, ok := listener.Addr().(*net.TCPAddr); ok {
+				actual = tcpAddr.Port
+			}
+			return listener, actual, nil
+		}
+		lastErr = err
+
+		if strict {
+			return nil, port, err
+		}
+	}
+	return nil, port, fmt.Errorf("ports %d-%d unavailable: %w", port, port+retries, lastErr)
+}

--- a/cmd/sqs-ui/listen_test.go
+++ b/cmd/sqs-ui/listen_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestListenWithFallback_BindsRequestedPortWhenAvailable(t *testing.T) {
+	listener, port, err := listenWithFallback("0", 0, false)
+	if err != nil {
+		t.Fatalf("expected to bind ephemeral port, got error: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	if port <= 0 {
+		t.Errorf("expected positive port number, got %d", port)
+	}
+
+	addr := listener.Addr().(*net.TCPAddr)
+	if addr.Port == 0 {
+		t.Error("listener bound to port 0 — expected a real ephemeral port")
+	}
+}
+
+func TestListenWithFallback_FallsBackToNextPortWhenFirstIsTaken(t *testing.T) {
+	first, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("could not reserve a port: %v", err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	taken := first.Addr().(*net.TCPAddr).Port
+
+	second, port, err := listenWithFallback(strconv.Itoa(taken), 5, false)
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got: %v", err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+
+	if port == taken {
+		t.Errorf("expected fallback to a different port, but got the same: %d", port)
+	}
+	if port < taken || port > taken+5 {
+		t.Errorf("expected port between %d and %d, got %d", taken+1, taken+5, port)
+	}
+}
+
+func TestListenWithFallback_FailsImmediatelyWhenStrictAndPortTaken(t *testing.T) {
+	first, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("could not reserve a port: %v", err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	taken := first.Addr().(*net.TCPAddr).Port
+
+	listener, _, err := listenWithFallback(strconv.Itoa(taken), 10, true)
+	if err == nil {
+		_ = listener.Close()
+		t.Fatal("expected strict mode to refuse fallback, but it succeeded")
+	}
+}
+
+func TestListenWithFallback_RejectsInvalidPort(t *testing.T) {
+	tests := []struct {
+		name string
+		port string
+	}{
+		{"non-numeric", "abc"},
+		{"negative", "-1"},
+		{"out-of-range", "70000"},
+		{"empty", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listener, _, err := listenWithFallback(tt.port, 0, false)
+			if err == nil {
+				_ = listener.Close()
+				t.Fatalf("expected error for invalid port %q, got none", tt.port)
+			}
+			if !strings.Contains(err.Error(), "invalid port") {
+				t.Errorf("expected 'invalid port' in error, got: %v", err)
+			}
+		})
+	}
+}

--- a/cmd/sqs-ui/main.go
+++ b/cmd/sqs-ui/main.go
@@ -68,8 +68,13 @@ func main() {
 	// Serve static files (this will handle root path too)
 	r.PathPrefix("/").Handler(http.StripPrefix("/", http.FileServer(http.FS(staticFS))))
 
+	srv := &http.Server{
+		Handler:           r,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
 	log.Printf("Server starting on http://localhost:%d", actualPort)
-	if err := http.Serve(listener, r); err != nil {
+	if err := srv.Serve(listener); err != nil {
 		log.Fatal("Server failed to start:", err)
 	}
 }

--- a/cmd/sqs-ui/main.go
+++ b/cmd/sqs-ui/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/cjunker/go-sqs-ui/internal/sqs"
@@ -12,10 +13,24 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const (
+	defaultPort = "8080"
+	portRetries = 10
+)
+
 func main() {
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
+	requestedPort, portFromEnv := os.LookupEnv("PORT")
+	if requestedPort == "" {
+		requestedPort = defaultPort
+		portFromEnv = false
+	}
+
+	listener, actualPort, err := listenWithFallback(requestedPort, portRetries, portFromEnv)
+	if err != nil {
+		log.Fatalf("Failed to bind: %v", err)
+	}
+	if requested, _ := strconv.Atoi(requestedPort); requested != actualPort {
+		log.Printf("⚠ Port %d was in use; serving on port %d instead", requested, actualPort)
 	}
 
 	sqsHandler, err := sqs.NewSQSHandler()
@@ -53,8 +68,8 @@ func main() {
 	// Serve static files (this will handle root path too)
 	r.PathPrefix("/").Handler(http.StripPrefix("/", http.FileServer(http.FS(staticFS))))
 
-	log.Printf("Server starting on port %s", port)
-	if err := http.ListenAndServe(":"+port, r); err != nil {
+	log.Printf("Server starting on http://localhost:%d", actualPort)
+	if err := http.Serve(listener, r); err != nil {
 		log.Fatal("Server failed to start:", err)
 	}
 }


### PR DESCRIPTION
## Summary
First slice of #15. Eliminates the most common silent demo-day failure: the default port 8080 already being held by another local-dev process. When a fallback happens it's now loudly logged.

Refs #15, #16

## Type
- [x] Feature (small, demo polish)

## Behavior

### Before
\`\`\`
$ make dev-start
Server starting on port 8080
Server failed to start:listen tcp :8080: bind: Only one usage of each socket address...
exit status 1
\`\`\`
The user had to spot the cryptic error and re-run with \`PORT=18181\`.

### After
\`\`\`
$ make dev-start
⚠ Port 8080 was in use; serving on port 8081 instead
Server starting on http://localhost:8081
\`\`\`

### Strict mode preserved
When \`PORT=8080\` is set **explicitly** via env var, the server still fails fast rather than silently using a different port than the user asked for. The fallback only kicks in for the implicit default.

## Implementation
Extracted \`listenWithFallback(portStr, retries, strict)\` into \`cmd/sqs-ui/listen.go\` for unit testing. \`main()\` now uses \`os.LookupEnv("PORT")\` to detect explicit-vs-default, passes \`strict\` accordingly, and switches from \`http.ListenAndServe\` to \`http.Serve(listener, ...)\` so the bound listener can carry forward.

## Testing
- [x] 4 new unit tests in \`cmd/sqs-ui/listen_test.go\`: ephemeral-port success, fallback when first taken, strict-mode refusal, invalid-port rejection
- [x] Manually verified: \`FORCE_DEMO_MODE=true go run ./cmd/sqs-ui\` while 8080 is held by another process → server bound 8081, demo endpoints respond
- [x] \`go test ./...\` — all packages pass

## Out of scope (follow-up PR)
Tag-filter UI hint (the second item in #15) is left for a separate PR — that's a backend response-shape change plus a frontend component, larger than this fits.

## Checklist
- [x] No secrets in code
- [x] No new \`any\` / \`interface{}\` introduced
- [x] Cross-platform: avoids \`syscall.EADDRINUSE\` (different code on Windows) by treating any bind failure as fallback-eligible in non-strict mode
- [x] Listener port read back from \`net.TCPAddr\` so \`:0\` ephemeral requests report the kernel-assigned port