### PR TITLE
chore(ci): bump golangci-lint-action to v8 for v2 config support

### DIFF
--- a/.github/workflows/ci-enhanced.yml
+++ b/.github/workflows/ci-enhanced.yml
@@ -2,11 +2,11 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [main, master, develop]
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [main, master, develop]
   schedule:
-    - cron: '0 0 * * 0'  # Weekly security scan on Sunday
+    - cron: '0 0 * * 0' # Weekly security scan on Sunday
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -25,7 +25,7 @@ jobs:
   # ============================================
   # Stage 1: Quick Checks (Parallel)
   # ============================================
-  
+
   lint-go:
     name: Lint Go Code
     runs-on: ubuntu-latest
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Full history for better analysis
+          fetch-depth: 0 # Full history for better analysis
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -43,7 +43,7 @@ jobs:
           cache: true
 
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           args: --timeout=5m --config=.golangci.yml
@@ -92,7 +92,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
-          exit-code: '0'  # Don't fail the build
+          exit-code: '0' # Don't fail the build
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v3
@@ -104,7 +104,7 @@ jobs:
         uses: securego/gosec@master
         with:
           args: '-no-fail -fmt sarif -out gosec-results.sarif ./...'
-          
+
       - name: Upload gosec results
         uses: github/codeql-action/upload-sarif@v3
         if: always()
@@ -119,7 +119,7 @@ jobs:
   # ============================================
   # Stage 2: Unit Tests (Parallel with Matrix)
   # ============================================
-  
+
   test-go:
     name: Test Go (${{ matrix.go-version }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -184,7 +184,7 @@ jobs:
   # ============================================
   # Stage 3: Coverage Analysis & Quality Gates
   # ============================================
-  
+
   coverage-check:
     name: Coverage Analysis & Quality Gates
     runs-on: ubuntu-latest
@@ -275,7 +275,7 @@ jobs:
   # ============================================
   # Stage 4: Build & Integration Tests
   # ============================================
-  
+
   build:
     name: Build Application
     runs-on: ubuntu-latest
@@ -400,7 +400,7 @@ jobs:
   # ============================================
   # Stage 5: Reporting & Notifications
   # ============================================
-  
+
   publish-results:
     name: Publish Test Results
     runs-on: ubuntu-latest
@@ -443,7 +443,7 @@ jobs:
   # ============================================
   # Quality Gate Decision
   # ============================================
-  
+
   quality-gate:
     name: Quality Gate Decision
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           cache: true
 
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           args: --timeout=5m


### PR DESCRIPTION
## Summary
PR #19 migrated \`.golangci.yml\` to v2 format. The CI workflow's \`golangci-lint-action@v6\` resolves \`version: latest\` to v1.64.8, which then errors with:

\`\`\`
Error: Command failed: golangci-lint config verify
Failed executing command with error: the configuration contains invalid elements
\`\`\`

\`golangci-lint-action@v8\` is the first stable release that supports v2 binaries via \`version: latest\`.

## Changes
- \`.github/workflows/ci.yml\` — \`@v6\` → \`@v8\`
- \`.github/workflows/ci-enhanced.yml\` — \`@v6\` → \`@v8\`

## Why this can't ride along on another PR
After #19 merged, **every** PR's Lint Go Code job started failing identically. This is the only fix; landing it unblocks #18 and #20's Lint Go check.

## Testing
Verified locally with the same v2 binary that CI will now pull (\`golangci-lint v2.11.4\`) — \`golangci-lint run ./...\` returns 0 issues against the v2 config.

Refs #16