### PR TITLE
fix(ci): replace hanging version check with binary presence test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Build Go binary
         run: |
           go build -v -o sqs-ui ./cmd/sqs-ui
-          ./sqs-ui -version || echo "Binary built successfully"
+          test -x sqs-ui
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
The `Build Application` job in `ci.yml` was hanging until the 6-hour job timeout. Cancelling run [25082100602](https://github.com/cjunks94/go-sqs-ui/actions/runs/25082100602) after 47 min surfaced this.

## Root cause
`./sqs-ui -version || echo "Binary built successfully"` — the binary has no flag parsing and no `-version` flag, so the command starts the HTTP server and runs forever. The `|| echo` fallback only fires on non-zero exit, not on a hang.

## Fix
Replace with `test -x sqs-ui`, which verifies the build produced an executable without launching it. `go build` already non-zeros on compile failure, so this is just a belt-and-braces presence check.

## Type
- [x] Bug fix

## Testing
- [x] Verified locally that `cmd/sqs-ui` has no `-version` flag (no `flag.` or `os.Args` references)
- [x] CI re-run on this branch will exercise the fix