### PR TITLE
fix(module): correct module path to github.com/cjunks94/go-sqs-ui

### DIFF
--- a/cmd/sqs-ui/main.go
+++ b/cmd/sqs-ui/main.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/cjunker/go-sqs-ui/internal/sqs"
-	"github.com/cjunker/go-sqs-ui/internal/static"
-	"github.com/cjunker/go-sqs-ui/internal/websocket"
+	"github.com/cjunks94/go-sqs-ui/internal/sqs"
+	"github.com/cjunks94/go-sqs-ui/internal/static"
+	"github.com/cjunks94/go-sqs-ui/internal/websocket"
 	"github.com/gorilla/mux"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cjunker/go-sqs-ui
+module github.com/cjunks94/go-sqs-ui
 
 go 1.25.0
 

--- a/internal/sqs/sqs.go
+++ b/internal/sqs/sqs.go
@@ -16,8 +16,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
-	"github.com/cjunker/go-sqs-ui/internal/demo"
-	internal_types "github.com/cjunker/go-sqs-ui/internal/types"
+	"github.com/cjunks94/go-sqs-ui/internal/demo"
+	internal_types "github.com/cjunks94/go-sqs-ui/internal/types"
 	"github.com/gorilla/mux"
 )
 

--- a/internal/sqs/sqs_test.go
+++ b/internal/sqs/sqs_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/cjunker/go-sqs-ui/internal/types"
-	"github.com/cjunker/go-sqs-ui/test/helpers"
+	"github.com/cjunks94/go-sqs-ui/internal/types"
+	"github.com/cjunks94/go-sqs-ui/test/helpers"
 	"github.com/gorilla/mux"
 )
 

--- a/internal/websocket/websocket.go
+++ b/internal/websocket/websocket.go
@@ -13,8 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
-	internal_sqs "github.com/cjunker/go-sqs-ui/internal/sqs"
-	internal_types "github.com/cjunker/go-sqs-ui/internal/types"
+	internal_sqs "github.com/cjunks94/go-sqs-ui/internal/sqs"
+	internal_types "github.com/cjunks94/go-sqs-ui/internal/types"
 	"github.com/gorilla/websocket"
 )
 

--- a/internal/websocket/websocket_test.go
+++ b/internal/websocket/websocket_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cjunker/go-sqs-ui/test/helpers"
+	"github.com/cjunks94/go-sqs-ui/test/helpers"
 	"github.com/gorilla/websocket"
 )
 

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cjunker/go-sqs-ui/internal/sqs"
-	"github.com/cjunker/go-sqs-ui/internal/types"
-	"github.com/cjunker/go-sqs-ui/internal/websocket"
-	"github.com/cjunker/go-sqs-ui/test/helpers"
+	"github.com/cjunks94/go-sqs-ui/internal/sqs"
+	"github.com/cjunks94/go-sqs-ui/internal/types"
+	"github.com/cjunks94/go-sqs-ui/internal/websocket"
+	"github.com/cjunks94/go-sqs-ui/test/helpers"
 	"github.com/gorilla/mux"
 )
 


### PR DESCRIPTION
## Summary
The module was declared as `github.com/cjunker/go-sqs-ui` (missing the `s94`), which doesn't match the actual repository path and breaks `go get` / `go install`. This corrects `go.mod` and all internal import paths.

**Recommend merging this first** — it's self-contained (Go imports only) and unblocks the other cleanup PRs.

## Changes
- `go.mod` module path
- Import paths in `cmd/sqs-ui`, `internal/sqs`, `internal/websocket`, `test/integration`

## Verification
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (all packages)
- `golangci-lint run ./...` ✅ (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project’s module identity to the new repository path.
  * Aligned internal, WebSocket, SQS, and integration test import paths to the new module namespace.
  * Kept application behavior, routing, and test logic unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->