### PR TITLE
fix(gitignore): anchor binary patterns to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,9 @@
 # Go workspace file
 go.work
 
-# Built binary
-sqs-ui
-go-sqs-ui
+# Built binary (anchored to repo root so they don't match the cmd/sqs-ui source dir)
+/sqs-ui
+/go-sqs-ui
 
 # IDE specific files
 .idea/


### PR DESCRIPTION
## Summary
The unanchored patterns `sqs-ui` and `go-sqs-ui` (intended for the built binaries) also matched the `cmd/sqs-ui/` **source** directory, so tooling that honors `.gitignore` (ripgrep, fzf, editors, etc.) silently skipped it. Anchoring both to the repo root (`/sqs-ui`, `/go-sqs-ui`) keeps them scoped to root-level build artifacts.

## Verification
Confirmed `git check-ignore cmd/sqs-ui/main.go` no longer matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules so root-level compiled binaries (for the UI tools) are no longer tracked, while avoiding changes to similarly named files in subfolders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->