### PR TITLE
fix(deps): bump golang.org/x/net to v0.38.0 to patch CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   security-events: write
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.23'
   NODE_VERSION: '20'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A lightweight, web-based UI for managing AWS SQS queues built with Go and vanill
 
 ## Prerequisites
 
-- Go 1.21 or higher
+- Go 1.23 or higher
 - Node.js 18+ (for frontend testing and development)
 - AWS credentials configured (via `~/.aws/credentials`, environment variables, or IAM role)
 - Appropriate AWS permissions for SQS operations:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cjunker/go-sqs-ui
 
-go 1.21
+go 1.23.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.0
@@ -22,5 +22,5 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.26.5 // indirect
 	github.com/aws/smithy-go v1.19.0 // indirect
-	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -32,5 +32,5 @@ github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
-golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=


### PR DESCRIPTION
## Summary
Resolves the 13 Trivy code-scanning alerts (9 high / 4 medium) reported across the open PRs. All originate from **`golang.org/x/net` v0.17.0** (~2 years stale):

- HTTP/2 `CONTINUATION` flood DoS
- `x/net/html` parsing DoS (infinite loop, quadratic / non-linear parsing)
- `x/net/idna` punycode privilege escalation
- `x/net/http/httpproxy` IPv6-zone proxy bypass

**v0.38.0** is the minimum release that clears every flagged CVE (newest is CVE-2025-22872, fixed in v0.38.0).

## Changes
- `go.mod` / `go.sum`: `golang.org/x/net` v0.17.0 -> v0.38.0
- `go` directive raised to 1.23.0 (required by x/net v0.38.0)
- CI `GO_VERSION` 1.21 -> 1.23 and README prerequisite updated to match

## Verification
- `go build ./...` passed
- `go vet ./...` passed
- `go test -race ./...` passed (all packages, matches CI)

Note: edits `.github/workflows/ci.yml` (GO_VERSION line only) — no textual overlap with the frontend PR's glob changes, so they merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project to use Go 1.23 across development, builds, and CI checks.
  * Revised the setup requirements in the documentation to match the new Go version.
  * Refreshed a bundled Go dependency to a newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->