### PR TITLE
fix(deps): bump golang.org/x/net to v0.56.0 to fully clear Trivy alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   security-events: write
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.25'
   NODE_VERSION: '20'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A lightweight, web-based UI for managing AWS SQS queues built with Go and vanill
 
 ## Prerequisites
 
-- Go 1.23 or higher
+- Go 1.25 or higher
 - Node.js 18+ (for frontend testing and development)
 - AWS credentials configured (via `~/.aws/credentials`, environment variables, or IAM role)
 - Appropriate AWS permissions for SQS operations:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cjunker/go-sqs-ui
 
-go 1.23.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.0
@@ -22,5 +22,5 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.26.5 // indirect
 	github.com/aws/smithy-go v1.19.0 // indirect
-	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -32,5 +32,5 @@ github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=


### PR DESCRIPTION
## Summary

Follow-up to #30. The v0.38.0 bump did not clear all Trivy code-scanning alerts — Trivy reports newer `golang.org/x/net` advisories (html parsing DoS, idna punycode privilege escalation, HTTP/2 SETTINGS DoS) with fixed versions of **v0.45.0 / v0.53.0 / v0.55.0**.

Bump to the latest **v0.56.0**, which covers all of them (9 remaining alerts → 0).

## Changes
- `go.mod` / `go.sum`: `golang.org/x/net` v0.38.0 → v0.56.0
- `go` directive → 1.25.0 (required by x/net ≥ v0.55.0)
- CI `GO_VERSION` 1.23 → 1.25 and README prerequisite updated to match

## Verification
- `go build ./...`, `go vet ./...`, `go test -race ./...` all pass

After merge, the other open PRs (#26–#29) need a rebase to pick this up and turn their Trivy checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)