### PR TITLE
feat(stats): mount the QueueStatistics panel on app init (#33)

### DIFF
--- a/internal/static/files/modules/sqsApp.js
+++ b/internal/static/files/modules/sqsApp.js
@@ -40,6 +40,7 @@ export class SQSApp {
       await this.awsContextHandler.load();
       await this.queueManager.loadQueues();
       this.setupEventListeners();
+      this.mountStatisticsPanel();
       this.webSocketManager.connect();
 
       // Initialize keyboard navigation
@@ -168,6 +169,23 @@ export class SQSApp {
       console.error('Error retrying messages:', error);
       toast.error('Failed to retry some messages');
     }
+  }
+
+  /**
+   * Mount the QueueStatistics panel in place of the static placeholder in
+   * index.html. Without this the module is never rendered, load() no-ops
+   * (this.element is null), and the `s` toggle has nothing real to show.
+   */
+  mountStatisticsPanel() {
+    const placeholder = document.getElementById('queueStatisticsPanel');
+    if (!placeholder) return;
+
+    const panel = this.queueStatistics.init();
+    // Preserve the placeholder's id and hidden-by-default state so the
+    // existing toggleStatisticsPanel() shortcut keeps working.
+    panel.id = placeholder.id;
+    panel.classList.add('hidden');
+    placeholder.replaceWith(panel);
   }
 
   cleanup() {

--- a/test/mountStatistics.test.js
+++ b/test/mountStatistics.test.js
@@ -1,0 +1,56 @@
+/**
+ * Regression tests for mounting the QueueStatistics panel (issue #33).
+ * Uses the real SQSApp + QueueStatistics modules.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { SQSApp } from '@/sqsApp.js';
+
+describe('SQSApp.mountStatisticsPanel', () => {
+  beforeEach(() => {
+    // DOM anchors required by the UIComponent-based modules SQSApp constructs.
+    document.body.innerHTML = `
+      <ul id="queueList"></ul>
+      <div id="awsContextDetails"></div>
+      <div id="messageList"></div>
+      <div id="queueAttributes"></div>
+      <div class="queue-statistics-panel hidden" id="queueStatisticsPanel">
+        <h3>Queue Statistics</h3>
+        <div class="statistics-content"><div class="loading">Loading statistics...</div></div>
+      </div>
+    `;
+    // QueueStatistics.init() grabs a 2D canvas context.
+    globalThis.HTMLCanvasElement.prototype.getContext = vi.fn(() => ({}));
+  });
+
+  it('replaces the placeholder with the functional statistics panel', () => {
+    const app = new SQSApp();
+    app.mountStatisticsPanel();
+
+    const panels = document.querySelectorAll('.queue-statistics-panel');
+    expect(panels).toHaveLength(1); // placeholder replaced, not duplicated
+
+    const panel = panels[0];
+    expect(panel.id).toBe('queueStatisticsPanel');
+    expect(panel.classList.contains('hidden')).toBe(true);
+    // The real module structure is present (the static placeholder lacked these).
+    expect(panel.querySelector('#stat-total')).toBeTruthy();
+    expect(panel.querySelector('.stats-dlq-section')).toBeTruthy();
+    // The module now has a live element, so load()/updateDisplay() can work.
+    expect(app.queueStatistics.element).toBe(panel);
+  });
+
+  it('toggleStatisticsPanel shows the mounted panel', () => {
+    const app = new SQSApp();
+    app.mountStatisticsPanel();
+
+    app.keyboardNavigation.toggleStatisticsPanel();
+    expect(document.querySelector('.queue-statistics-panel').classList.contains('hidden')).toBe(false);
+  });
+
+  it('is a no-op when the placeholder is absent', () => {
+    document.getElementById('queueStatisticsPanel').remove();
+    const app = new SQSApp();
+    expect(() => app.mountStatisticsPanel()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #33.

`SQSApp` constructed `QueueStatistics` and `queueManager.selectQueue()` already called `queueStatistics.load()`, but **`init()` was never called and the panel was never appended to the DOM**. As a result `load()` → `updateDisplay()` returned early (`this.element` was null), the statistics UI never rendered, and `KeyboardNavigation.toggleStatisticsPanel()` (the `s` shortcut) toggled only the empty static placeholder.

## Change
- New `SQSApp.mountStatisticsPanel()`, called from `init()`. It builds the real panel via `QueueStatistics.init()` and **replaces the static `#queueStatisticsPanel` placeholder** in `index.html`, preserving its `id` and hidden-by-default state so the existing toggle keeps working.
- Now that the module has a live `element`, the existing `load()` call on queue select renders real stats.

## Tests
Added `test/mountStatistics.test.js` (real `SQSApp` + `QueueStatistics`):
- placeholder is replaced (not duplicated) with the functional panel
- `toggleStatisticsPanel()` shows the mounted panel
- no-op when the placeholder is absent

Verified the test fails if the mount is disabled. Full suite: **455 passing**; ESLint, Prettier, `go build` clean.

> Note: visual/charts behavior (canvas) still warrants a manual smoke test in a real browser, but the panel is now reachable and data-bound. Related pre-existing issue #22 (duplicate stats fetch on DLQ select) is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Queue Statistics panel to the app flow so it appears after queues load and before the connection is established.
  * The statistics panel now mounts into the page while preserving existing show/hide behavior.

* **Tests**
  * Added regression coverage for the statistics panel mounting behavior.
  * Verified the panel can be shown, is wired correctly, and safely handles missing page placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->