### PR TITLE
fix(browser): thread pagination offset through to the backend (#34)

### DIFF
--- a/internal/sqs/sqs.go
+++ b/internal/sqs/sqs.go
@@ -298,12 +298,21 @@ func (h *SQSHandler) GetMessages(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	log.Printf("GetMessages: Fetching up to %d messages for queue %s", limit, queueURL)
+	// Receive enough messages to cover the requested offset window before
+	// slicing below. SQS caps a single ReceiveMessage at 10, so deep offsets
+	// are not reachable for live queues (inherent SQS limitation); demo/mock
+	// clients honor MaxNumberOfMessages against their full message set.
+	receiveCount := int32(offset) + limit
+	if receiveCount > 10 {
+		receiveCount = 10
+	}
+
+	log.Printf("GetMessages: Fetching up to %d messages (offset %d, limit %d) for queue %s", receiveCount, offset, limit, queueURL)
 	ctx := context.Background()
 
 	result, err := h.Client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
 		QueueUrl:              aws.String(queueURL),
-		MaxNumberOfMessages:   limit,
+		MaxNumberOfMessages:   receiveCount,
 		WaitTimeSeconds:       1,
 		AttributeNames:        []types.QueueAttributeName{types.QueueAttributeNameAll},
 		MessageAttributeNames: []string{"All"},

--- a/internal/sqs/sqs.go
+++ b/internal/sqs/sqs.go
@@ -318,7 +318,9 @@ func (h *SQSHandler) GetMessages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("GetMessages: Fetching up to %d messages (offset %d, limit %d) for queue %s", receiveCount, offset, limit, queueURL)
-	ctx := context.Background()
+	// Use the request context so the long-poll respects client disconnects and
+	// server deadlines instead of outliving the HTTP request.
+	ctx := r.Context()
 
 	result, err := h.Client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
 		QueueUrl:              aws.String(queueURL),

--- a/internal/sqs/sqs.go
+++ b/internal/sqs/sqs.go
@@ -299,12 +299,22 @@ func (h *SQSHandler) GetMessages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Receive enough messages to cover the requested offset window before
-	// slicing below. SQS caps a single ReceiveMessage at 10, so deep offsets
-	// are not reachable for live queues (inherent SQS limitation); demo/mock
-	// clients honor MaxNumberOfMessages against their full message set.
-	receiveCount := int32(offset) + limit
-	if receiveCount > 10 {
-		receiveCount = 10
+	// slicing below. Live SQS hard-caps a single ReceiveMessage at 10 and does
+	// not return a stable ordered set across calls, so deep offsets are not
+	// reachable for live queues (inherent SQS limitation). Demo/mock clients
+	// hold the full message set, so they can serve the whole offset window.
+	// Compute in int and clamp before the int32 cast to avoid overflow on a
+	// large offset wrapping MaxNumberOfMessages negative.
+	maxReceive := 10
+	if h.isDemo {
+		maxReceive = 1000
+	}
+	receiveCount := offset + int(limit)
+	if receiveCount > maxReceive {
+		receiveCount = maxReceive
+	}
+	if receiveCount < 1 {
+		receiveCount = 1
 	}
 
 	log.Printf("GetMessages: Fetching up to %d messages (offset %d, limit %d) for queue %s", receiveCount, offset, limit, queueURL)
@@ -312,7 +322,7 @@ func (h *SQSHandler) GetMessages(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.Client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
 		QueueUrl:              aws.String(queueURL),
-		MaxNumberOfMessages:   receiveCount,
+		MaxNumberOfMessages:   int32(receiveCount),
 		WaitTimeSeconds:       1,
 		AttributeNames:        []types.QueueAttributeName{types.QueueAttributeNameAll},
 		MessageAttributeNames: []string{"All"},

--- a/internal/sqs/sqs_test.go
+++ b/internal/sqs/sqs_test.go
@@ -40,8 +40,11 @@ func (c *maxHonoringClient) ReceiveMessage(ctx context.Context, params *awssqs.R
 
 func newMaxHonoringClient(queueURL string, n int) *maxHonoringClient {
 	mc := helpers.NewMockSQSClient()
+	// Distinct, increasing timestamps so the handler's newest-first sort is
+	// deterministic: msg-n is newest, msg-1 is oldest.
 	for i := 1; i <= n; i++ {
-		mc.AddMessage(queueURL, fmt.Sprintf("msg-%d", i), fmt.Sprintf("body %d", i))
+		ts := fmt.Sprintf("%d", 1640995200000+i)
+		mc.AddMessageWithTimestamp(queueURL, fmt.Sprintf("msg-%d", i), fmt.Sprintf("body %d", i), ts)
 	}
 	return &maxHonoringClient{MockSQSClient: mc}
 }
@@ -71,8 +74,15 @@ func TestSQSHandler_GetMessages_OffsetDemoVsLive(t *testing.T) {
 	hDemo := &SQSHandler{Client: demo, isDemo: true}
 	rr := httptest.NewRecorder()
 	hDemo.GetMessages(rr, getMessagesReq(queueURL, "?limit=10&offset=20"))
-	if got := len(decodeMessages(t, rr)); got != 10 {
-		t.Errorf("demo offset=20: expected 10 messages, got %d", got)
+	demoMsgs := decodeMessages(t, rr)
+	if len(demoMsgs) != 10 {
+		t.Fatalf("demo offset=20: expected 10 messages, got %d", len(demoMsgs))
+	}
+	// Newest-first sort of msg-1..msg-30 is msg-30..msg-1; offset 20 starts the
+	// page at msg-10 and runs to msg-1 — proving it's the requested page, not
+	// just the first 10.
+	if demoMsgs[0].MessageId != "msg-10" || demoMsgs[9].MessageId != "msg-1" {
+		t.Errorf("demo offset=20: expected page msg-10..msg-1, got %s..%s", demoMsgs[0].MessageId, demoMsgs[9].MessageId)
 	}
 	if demo.lastMax != 30 {
 		t.Errorf("demo: expected receiveCount 30, got %d", demo.lastMax)

--- a/internal/sqs/sqs_test.go
+++ b/internal/sqs/sqs_test.go
@@ -2,6 +2,7 @@ package sqs
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -10,10 +11,107 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/cjunks94/go-sqs-ui/internal/types"
 	"github.com/cjunks94/go-sqs-ui/test/helpers"
 	"github.com/gorilla/mux"
 )
+
+// maxHonoringClient honors MaxNumberOfMessages like the real demo/live SQS
+// clients (the default MockSQSClient intentionally ignores it to ease offset
+// testing). It also records the last requested max so tests can assert the
+// receiveCount clamp/overflow handling.
+type maxHonoringClient struct {
+	*helpers.MockSQSClient
+	lastMax int32
+}
+
+func (c *maxHonoringClient) ReceiveMessage(ctx context.Context, params *awssqs.ReceiveMessageInput, optFns ...func(*awssqs.Options)) (*awssqs.ReceiveMessageOutput, error) {
+	c.lastMax = params.MaxNumberOfMessages
+	out, err := c.MockSQSClient.ReceiveMessage(ctx, params, optFns...)
+	if err != nil {
+		return out, err
+	}
+	if maxN := int(params.MaxNumberOfMessages); maxN > 0 && maxN < len(out.Messages) {
+		out.Messages = out.Messages[:maxN]
+	}
+	return out, nil
+}
+
+func newMaxHonoringClient(queueURL string, n int) *maxHonoringClient {
+	mc := helpers.NewMockSQSClient()
+	for i := 1; i <= n; i++ {
+		mc.AddMessage(queueURL, fmt.Sprintf("msg-%d", i), fmt.Sprintf("body %d", i))
+	}
+	return &maxHonoringClient{MockSQSClient: mc}
+}
+
+func decodeMessages(t *testing.T, rr *httptest.ResponseRecorder) []types.Message {
+	t.Helper()
+	var msgs []types.Message
+	if err := json.NewDecoder(rr.Body).Decode(&msgs); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	return msgs
+}
+
+func getMessagesReq(queueURL, query string) *http.Request {
+	req := httptest.NewRequest("GET", "/api/queues/{queueUrl}/messages"+query, nil)
+	return mux.SetURLVars(req, map[string]string{"queueUrl": queueURL})
+}
+
+// TestSQSHandler_GetMessages_OffsetDemoVsLive verifies the receiveCount fix:
+// demo clients (which hold the full set) can serve deep offsets, while live
+// SQS is clamped to its 10-message per-fetch cap.
+func TestSQSHandler_GetMessages_OffsetDemoVsLive(t *testing.T) {
+	const queueURL = "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"
+
+	// Demo: offset 20 is reachable (receives offset+limit, not clamped to 10).
+	demo := newMaxHonoringClient(queueURL, 30)
+	hDemo := &SQSHandler{Client: demo, isDemo: true}
+	rr := httptest.NewRecorder()
+	hDemo.GetMessages(rr, getMessagesReq(queueURL, "?limit=10&offset=20"))
+	if got := len(decodeMessages(t, rr)); got != 10 {
+		t.Errorf("demo offset=20: expected 10 messages, got %d", got)
+	}
+	if demo.lastMax != 30 {
+		t.Errorf("demo: expected receiveCount 30, got %d", demo.lastMax)
+	}
+
+	// Live: clamped to SQS's 10 cap, so offset 20 is unreachable (empty page).
+	live := newMaxHonoringClient(queueURL, 30)
+	hLive := &SQSHandler{Client: live, isDemo: false}
+	rr = httptest.NewRecorder()
+	hLive.GetMessages(rr, getMessagesReq(queueURL, "?limit=10&offset=20"))
+	if got := len(decodeMessages(t, rr)); got != 0 {
+		t.Errorf("live offset=20: expected 0 messages, got %d", got)
+	}
+	if live.lastMax != 10 {
+		t.Errorf("live: expected receiveCount clamped to 10, got %d", live.lastMax)
+	}
+}
+
+// TestSQSHandler_GetMessages_OffsetNoOverflow ensures a huge offset does not
+// wrap the int32 MaxNumberOfMessages negative (which SQS would reject).
+func TestSQSHandler_GetMessages_OffsetNoOverflow(t *testing.T) {
+	const queueURL = "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"
+	client := newMaxHonoringClient(queueURL, 30)
+	handler := &SQSHandler{Client: client, isDemo: false}
+
+	rr := httptest.NewRecorder()
+	// 3_000_000_000 overflows int32; the clamp must run in int first.
+	handler.GetMessages(rr, getMessagesReq(queueURL, "?limit=10&offset=3000000000"))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if client.lastMax != 10 {
+		t.Errorf("expected clamped receiveCount 10 (no overflow), got %d", client.lastMax)
+	}
+	if got := len(decodeMessages(t, rr)); got != 0 {
+		t.Errorf("expected 0 messages for huge offset, got %d", got)
+	}
+}
 
 func TestSQSHandler_ListQueues(t *testing.T) {
 	tests := []struct {

--- a/internal/static/files/modules/apiService.js
+++ b/internal/static/files/modules/apiService.js
@@ -32,8 +32,8 @@ export class APIService {
     return this.request(`/api/queues?limit=${limit}`);
   }
 
-  static async getMessages(queueUrl, limit = 10) {
-    return this.request(`/api/queues/${encodeURIComponent(queueUrl)}/messages?limit=${limit}`);
+  static async getMessages(queueUrl, limit = 10, offset = 0) {
+    return this.request(`/api/queues/${encodeURIComponent(queueUrl)}/messages?limit=${limit}&offset=${offset}`);
   }
 
   static async sendMessage(queueUrl, messageBody) {

--- a/internal/static/files/modules/queueBrowser.js
+++ b/internal/static/files/modules/queueBrowser.js
@@ -26,7 +26,9 @@ export class QueueBrowser {
     this.appState = appState;
     this.isOpen = false;
     this.currentPage = 1;
-    this.itemsPerPage = 50;
+    // SQS caps a single ReceiveMessage at 10, so the page size is bounded by it.
+    this.maxItemsPerPage = 10;
+    this.itemsPerPage = 10;
     this.totalItems = 0;
     this.messages = [];
     this.element = null;
@@ -97,9 +99,8 @@ export class QueueBrowser {
                     <div class="items-per-page-control">
                         <label>Items per page:</label>
                         <select class="items-per-page-select">
-                            <option value="25">25</option>
-                            <option value="50" selected>50</option>
-                            <option value="100">100</option>
+                            <option value="5">5</option>
+                            <option value="10" selected>10</option>
                         </select>
                     </div>
                 </div>
@@ -161,12 +162,14 @@ export class QueueBrowser {
    * @param {number} offset - Offset for pagination
    * @returns {Promise<Object>} Response with messages and total count
    */
-  async fetchMessagesWithPagination(queueUrl, limit, _offset) {
-    // First, try to get messages with the standard API
-    const messages = await APIService.getMessages(queueUrl, limit);
+  async fetchMessagesWithPagination(queueUrl, limit, offset) {
+    // SQS caps a single fetch at 10 messages; the backend applies the offset
+    // against what it receives. Deep offsets are only fully reachable for
+    // demo/mock queues — for live SQS this pages within the first batch
+    // (inherent SQS limitation, see issue #34).
+    const cappedLimit = Math.min(limit, this.maxItemsPerPage);
+    const messages = await APIService.getMessages(queueUrl, cappedLimit, offset);
 
-    // For now, simulate pagination since backend might not support it yet
-    // In production, this would be a single API call with offset
     const queue = this.appState.getCurrentQueue();
     const totalCount = parseInt(queue.attributes?.ApproximateNumberOfMessages || '0');
 
@@ -347,7 +350,8 @@ export class QueueBrowser {
    * @returns {Promise<void>}
    */
   async setItemsPerPage(count) {
-    this.itemsPerPage = count;
+    // Clamp to the SQS per-fetch cap so pages stay coherent.
+    this.itemsPerPage = Math.min(count, this.maxItemsPerPage);
     this.currentPage = 1;
     await this.loadPage(1);
   }

--- a/test/apiService.test.js
+++ b/test/apiService.test.js
@@ -120,7 +120,7 @@ describe('APIService', () => {
 
       const result = await APIService.getMessages(queueUrl);
 
-      expect(fetch).toHaveBeenCalledWith(`/api/queues/${encodeURIComponent(queueUrl)}/messages?limit=10`, {
+      expect(fetch).toHaveBeenCalledWith(`/api/queues/${encodeURIComponent(queueUrl)}/messages?limit=10&offset=0`, {
         headers: { 'Content-Type': 'application/json' },
       });
       expect(result).toEqual(mockMessages);

--- a/test/helpers/test_helpers.go
+++ b/test/helpers/test_helpers.go
@@ -52,12 +52,18 @@ func (m *MockSQSClient) AddQueue(url string) {
 
 // AddMessage adds a test message to the specified queue.
 func (m *MockSQSClient) AddMessage(queueURL, messageID, body string) {
+	m.AddMessageWithTimestamp(queueURL, messageID, body, "1640995200000")
+}
+
+// AddMessageWithTimestamp adds a message with an explicit SentTimestamp, letting
+// tests control ordering (GetMessages sorts on SentTimestamp before paginating).
+func (m *MockSQSClient) AddMessageWithTimestamp(queueURL, messageID, body, sentTimestamp string) {
 	msg := types.Message{
 		MessageId:     aws.String(messageID),
 		Body:          aws.String(body),
 		ReceiptHandle: aws.String(fmt.Sprintf("receipt-%s", messageID)),
 		Attributes: map[string]string{
-			"SentTimestamp": "1640995200000",
+			"SentTimestamp": sentTimestamp,
 		},
 	}
 	m.messages[queueURL] = append(m.messages[queueURL], msg)

--- a/test/queueBrowserPagination.test.js
+++ b/test/queueBrowserPagination.test.js
@@ -1,0 +1,48 @@
+/**
+ * Regression tests for queue browser pagination offset (issue #34).
+ * Uses the real QueueBrowser module (the sibling suite mocks it).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { APIService } from '@/apiService.js';
+import { QueueBrowser } from '@/queueBrowser.js';
+
+vi.mock('@/apiService.js', () => ({
+  APIService: { getMessages: vi.fn() },
+}));
+
+const QUEUE = {
+  url: 'https://sqs.us-east-1.amazonaws.com/123/test-queue',
+  name: 'test-queue',
+  attributes: { ApproximateNumberOfMessages: '30' },
+};
+
+describe('QueueBrowser pagination offset', () => {
+  let browser;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+    APIService.getMessages.mockResolvedValue([{ messageId: 'm1', body: 'b1' }]);
+    browser = new QueueBrowser({ getCurrentQueue: () => QUEUE });
+    browser.createBrowserUI(QUEUE);
+    document.body.appendChild(browser.element);
+  });
+
+  it('passes the computed offset to APIService.getMessages', async () => {
+    await browser.loadPage(2); // page 2, itemsPerPage 10 -> offset 10
+    expect(APIService.getMessages).toHaveBeenCalledWith(QUEUE.url, 10, 10);
+  });
+
+  it('page 1 uses offset 0', async () => {
+    await browser.loadPage(1);
+    expect(APIService.getMessages).toHaveBeenCalledWith(QUEUE.url, 10, 0);
+  });
+
+  it('clamps the page size to the SQS per-fetch cap (10)', async () => {
+    await browser.setItemsPerPage(100);
+    expect(browser.itemsPerPage).toBe(10);
+    // offset for page 1 is 0, limit clamped to 10
+    expect(APIService.getMessages).toHaveBeenLastCalledWith(QUEUE.url, 10, 0);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #34 (bounded approach). The queue browser's pager updated `currentPage` but **dropped the offset**, so every "page" refetched the same first messages.

## Root cause
- `APIService.getMessages` had no `offset` param.
- `queueBrowser.fetchMessagesWithPagination` ignored `_offset`.
- The backend *did* parse `?offset=`, but received only `limit` messages **before** offsetting, so any offset returned an empty page.
- The browser offered 25/50/100 per page, but SQS hard-caps a single `ReceiveMessage` at **10**.

## Changes
- `APIService.getMessages(queueUrl, limit, offset)` — sends `&offset=`.
- `queueBrowser` — threads the offset and caps page size to the SQS limit (10); selector reduced to 5/10.
- Backend `GetMessages` — receives `offset + limit` messages (clamped to SQS's 10) before slicing, so the offset returns the correct window.

## Limitation (documented inline)
SQS caps a single fetch at 10 and has no random-access pagination, so deep paging across a **live** queue isn't possible here — paging works fully for demo/mock queues and within the first batch for live queues. A deeper model (consume+cache / continuation cursor) would be a separate effort.

## Tests
- New `test/queueBrowserPagination.test.js` (real module): offset is computed and passed; page size clamps to 10.
- Existing Go `TestSQSHandler_GetMessagesWithOffset` still passes (the mock returns the full set for >10).
- Updated the apiService URL assertion for the new `&offset=0`.

Full suite: **455 passing**; ESLint, Prettier, `go build`, `go test`, golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added true offset-based pagination for queue messages, enabling navigation to deeper pages (including consistent offset/limit handling end-to-end).
* **Bug Fixes**
  * Improved fetching so later pages return the correct message window and requests align with per-fetch SQS limits (demo vs live behavior handled correctly).
  * Updated page-size controls to enforce the maximum capacity (default 10; options reduced; values are clamped).
* **Tests**
  * Added/updated regression coverage for offset behavior, per-fetch clamping, and UI pagination; expanded SQS and API query assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->