### PR TITLE
docs: refresh stale references after layout/version changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 ### 1. Test-Driven Development (TDD)
 
 - **ALWAYS** write tests before implementing new features
-- Maintain or improve the current test coverage (446 frontend + ~100 Go tests)
+- Maintain or improve the current test coverage (458 frontend + ~100 Go tests)
 - Run both frontend (`npm test`) and backend (`go test ./...`) tests before committing
 - Each new module should have a corresponding test file
 

--- a/MVP-STATUS.md
+++ b/MVP-STATUS.md
@@ -1,5 +1,11 @@
 # MVP Status: Message Navigation and Filtering
 
+> **Note (historical):** This is a point-in-time MVP report. The project layout
+> has since changed — the frontend now lives under `internal/static/files/`
+> (embedded into the binary) and the Go entry point is `cmd/sqs-ui/main.go`. The
+> file paths in the "Files Modified" section below reflect the original layout.
+> See `README.md` for the current structure.
+
 ## ✅ Completed Features
 
 ### 1. **Message Filtering** ✅

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ make dev-restart
 make run
 
 # Or directly
-go run .
+go run ./cmd/sqs-ui
 
 # Then open http://localhost:8080
 ```
@@ -212,7 +212,7 @@ The application automatically detects AWS credentials and switches between Demo 
 ## Building for Production
 
 ```bash
-go build -o sqs-ui .
+go build -o sqs-ui ./cmd/sqs-ui
 ./sqs-ui
 ```
 
@@ -231,7 +231,7 @@ go build -o sqs-ui .
 2. **No Framework**: Kept simple with vanilla JavaScript to minimize complexity and dependencies
 3. **Responsive Design**: CSS Grid and Flexbox for a modern, responsive layout
 4. **AWS-Inspired UI**: Design inspired by AWS Console and DataDog for familiar user experience
-5. **Comprehensive Testing**: 446 frontend tests using Vitest with full coverage of all modules
+5. **Comprehensive Testing**: 458 frontend tests using Vitest with full coverage of all modules
 
 ### Goals
 
@@ -245,7 +245,7 @@ go build -o sqs-ui .
 
 - `GET /api/aws-context` - Get AWS connection context information
 - `GET /api/queues?limit=20` - List queues with tag-based filtering and pagination
-- `GET /api/queues/{queueUrl}/messages?limit=10` - Get messages from a queue with pagination
+- `GET /api/queues/{queueUrl}/messages?limit=10&offset=0` - Get messages from a queue (offset paging works for demo/mock; live SQS is bounded by its 10-message-per-fetch cap)
 - `GET /api/queues/{queueUrl}/statistics` - Get queue statistics and metrics
 - `POST /api/queues/{queueUrl}/messages` - Send a message to a queue
 - `POST /api/queues/{queueUrl}/retry` - Retry a message from DLQ to source queue
@@ -254,14 +254,14 @@ go build -o sqs-ui .
 
 ## Testing
 
-The application includes comprehensive test coverage with 540+ tests across frontend (446 Vitest) and backend (Go).
+The application includes comprehensive test coverage with 560+ tests across frontend (458 Vitest) and backend (Go).
 
 ### Frontend Tests
 
 Run the comprehensive JavaScript test suite:
 
 ```bash
-# Run all tests (446 tests)
+# Run all tests (458 tests)
 npm test
 
 # Run tests in watch mode during development


### PR DESCRIPTION
## Summary
Brings the docs in line with the changes merged this session.

## Changes
- **Fixed broken commands**: `go run .` and `go build -o sqs-ui .` → `./cmd/sqs-ui` (the entry point is no longer at the repo root, so the old commands fail).
- **API docs**: noted the `offset` param on the messages endpoint and the SQS 10-message-per-fetch cap caveat.
- **Test counts**: updated to current (458 frontend; 560+ total).
- **MVP-STATUS.md**: added a historical-layout note so its old `static/` and root `*.go` paths point readers to the current structure in README, without rewriting the historical record.

README structure tree, module path, and Go version (1.25) were already correct from earlier PRs. PLAN.md milestone checkboxes left as historical.

Docs-only; Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and build instructions for the current app entry point.
  * Refreshed testing and coverage numbers to match the latest project state.
  * Clarified the messages API example to include offset-based pagination and note the fetch limits.
  * Added a historical note explaining that the MVP status report reflects an earlier layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->