### PR TITLE
fix: address 3 CodeRabbit findings missed in the first follow-up pass

### DIFF
--- a/internal/static/files/modules/messageFilter.js
+++ b/internal/static/files/modules/messageFilter.js
@@ -4,6 +4,31 @@
  */
 import { toast } from './toastManager.js';
 
+/**
+ * Escape HTML so untrusted message text can't inject markup when the
+ * highlighted result is assigned to innerHTML.
+ * @param {unknown} value
+ * @returns {string}
+ */
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Escape regex metacharacters so the user's filter is matched literally
+ * (prevents SyntaxError on inputs like "[" and ReDoS via crafted patterns).
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export class MessageFilter {
   constructor() {
     this.currentFilter = '';
@@ -218,10 +243,13 @@ export class MessageFilter {
    * @returns {string} HTML with highlighted matches
    */
   highlightMatches(text, searchTerm) {
-    if (!searchTerm || !text) return text;
+    if (!searchTerm || !text) return escapeHtml(text);
 
-    const regex = new RegExp(`(${searchTerm})`, 'gi');
-    return text.replace(regex, '<mark>$1</mark>');
+    // Escape the text (output goes to innerHTML) and treat the search term as
+    // a literal string, then wrap matches in <mark>.
+    const escapedText = escapeHtml(text);
+    const regex = new RegExp(`(${escapeRegExp(escapeHtml(searchTerm))})`, 'gi');
+    return escapedText.replace(regex, '<mark>$1</mark>');
   }
 
   /**

--- a/internal/static/files/modules/messageHandler.js
+++ b/internal/static/files/modules/messageHandler.js
@@ -620,6 +620,11 @@ export class MessageHandler extends UIComponent {
         if (expandedView) {
           expandedView.classList.remove('hidden');
         }
+        // Hide the collapsed view too, otherwise both panes render after a merge.
+        const collapsedView = messageItem.querySelector('.message-collapsed');
+        if (collapsedView) {
+          collapsedView.classList.add('hidden');
+        }
       }
     });
 

--- a/internal/static/files/modules/queueManager.js
+++ b/internal/static/files/modules/queueManager.js
@@ -10,6 +10,9 @@ export class QueueManager extends UIComponent {
   constructor(appState) {
     super('#queueList');
     this.appState = appState;
+    // Pending staggered-append timers, cleared before each (re)render so a
+    // refresh can't have a prior render append stale items after the reset.
+    this.renderTimers = [];
   }
 
   async loadQueues() {
@@ -29,6 +32,10 @@ export class QueueManager extends UIComponent {
   }
 
   renderQueues(queues, append = false) {
+    // Cancel any in-flight append timers from a previous render.
+    this.renderTimers.forEach((timer) => clearTimeout(timer));
+    this.renderTimers = [];
+
     if (!append) {
       this.setContent('');
       this.removeLoadMoreButton();
@@ -42,10 +49,11 @@ export class QueueManager extends UIComponent {
     }
 
     queues.forEach((queue, index) => {
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         const queueItem = this.createQueueItem(queue);
         this.element.appendChild(queueItem);
       }, index * 50);
+      this.renderTimers.push(timer);
     });
   }
 

--- a/internal/static/files/modules/queueManager.js
+++ b/internal/static/files/modules/queueManager.js
@@ -32,11 +32,13 @@ export class QueueManager extends UIComponent {
   }
 
   renderQueues(queues, append = false) {
-    // Cancel any in-flight append timers from a previous render.
-    this.renderTimers.forEach((timer) => clearTimeout(timer));
-    this.renderTimers = [];
-
     if (!append) {
+      // Full (re)render: cancel in-flight append timers from a prior render so
+      // a refresh can't reappend stale items after the list is cleared.
+      // Append mode must NOT cancel — the first page's staggered timers may
+      // still be pending when "Load More" fires.
+      this.renderTimers.forEach((timer) => clearTimeout(timer));
+      this.renderTimers = [];
       this.setContent('');
       this.removeLoadMoreButton();
     } else {

--- a/test/queueManagerRender.test.js
+++ b/test/queueManagerRender.test.js
@@ -1,0 +1,29 @@
+/**
+ * Regression test: QueueManager must cancel pending staggered-append timers
+ * when a new render starts, so a refresh can't reappend stale items.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { QueueManager } from '@/queueManager.js';
+
+vi.mock('@/apiService.js', () => ({ APIService: { getQueues: vi.fn() } }));
+
+const q = (name) => ({ name, url: `https://sqs/${name}`, attributes: {} });
+
+describe('QueueManager render timer cancellation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '<ul id="queueList"></ul>';
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('cancels pending append timers when a new render starts', () => {
+    const qm = new QueueManager({});
+    qm.renderQueues([q('a'), q('b'), q('c')]); // schedules 3 deferred appends
+    qm.renderQueues([q('z')]); // must clear the 3 and reset before scheduling 1
+    vi.runAllTimers();
+
+    const names = Array.from(document.querySelectorAll('#queueList .queue-name')).map((el) => el.textContent);
+    expect(names).toEqual(['z']); // stale a/b/c never appended
+  });
+});

--- a/test/queueManagerRender.test.js
+++ b/test/queueManagerRender.test.js
@@ -17,13 +17,25 @@ describe('QueueManager render timer cancellation', () => {
   });
   afterEach(() => vi.useRealTimers());
 
-  it('cancels pending append timers when a new render starts', () => {
+  it('cancels pending timers when a full re-render starts', () => {
     const qm = new QueueManager({});
     qm.renderQueues([q('a'), q('b'), q('c')]); // schedules 3 deferred appends
-    qm.renderQueues([q('z')]); // must clear the 3 and reset before scheduling 1
+    qm.renderQueues([q('z')]); // full render: must clear the 3 and reset before scheduling 1
     vi.runAllTimers();
 
     const names = Array.from(document.querySelectorAll('#queueList .queue-name')).map((el) => el.textContent);
     expect(names).toEqual(['z']); // stale a/b/c never appended
+  });
+
+  it('does NOT cancel pending timers during an append (Load More)', () => {
+    const qm = new QueueManager({});
+    qm.renderQueues([q('a'), q('b'), q('c')]); // first-page timers still pending
+    qm.renderQueues([q('d')], true); // append before they fire — must keep all
+    vi.runAllTimers();
+
+    const names = Array.from(document.querySelectorAll('#queueList .queue-name'))
+      .map((el) => el.textContent)
+      .sort();
+    expect(names).toEqual(['a', 'b', 'c', 'd']); // nothing dropped
   });
 });

--- a/test/xssEscaping.test.js
+++ b/test/xssEscaping.test.js
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { APIService } from '@/apiService.js';
 import { QueueBrowser } from '@/queueBrowser.js';
 import { QueueStatistics } from '@/queueStatistics.js';
+import { MessageFilter } from '@/messageFilter.js';
 
 vi.mock('@/apiService.js');
 
@@ -63,6 +64,31 @@ describe('XSS escaping (real modules)', () => {
       expect(errorTypesEl.querySelector('img')).toBeNull();
       expect(errorTypesEl.querySelector('.error-type-item').textContent).toBe(`${XSS}: 2`);
       expect(window.__pwned).toBeUndefined();
+    });
+  });
+
+  describe('MessageFilter.highlightMatches', () => {
+    it('escapes HTML in the message text (output is assigned to innerHTML)', () => {
+      const filter = new MessageFilter();
+      const out = filter.highlightMatches(XSS, 'src');
+
+      // No live markup: the raw tag must be escaped...
+      expect(out).not.toContain('<img');
+      expect(out).toContain('&lt;img');
+      // ...and the literal match is still highlighted.
+      expect(out).toContain('<mark>');
+    });
+
+    it('treats a regex-special search term literally (no SyntaxError)', () => {
+      const filter = new MessageFilter();
+      expect(() => filter.highlightMatches('a[b]c', '[')).not.toThrow();
+      const out = filter.highlightMatches('a[b]c', '[');
+      expect(out).toContain('<mark>[</mark>');
+    });
+
+    it('escapes text even when there is no search term', () => {
+      const filter = new MessageFilter();
+      expect(filter.highlightMatches('<b>x</b>', '')).toBe('&lt;b&gt;x&lt;/b&gt;');
     });
   });
 });


### PR DESCRIPTION
## Summary
While reviewing the original #29 PR comments, three CodeRabbit findings turned out to be unaddressed — they were posted in a later review pass after the first follow-up (#32) was scoped.

## Fixes
- **`messageFilter.highlightMatches` — 🔴 Critical (Security):** it built a regex from raw user input and returned raw message text as HTML. A filter like `[` threw a `SyntaxError`, and message previews containing markup executed once assigned to `innerHTML` (line 482 of messageHandler). Now escapes the text and treats the search term as a literal string (also guards ReDoS).
- **`queueManager.renderQueues` — 🟠 Major:** staggered `setTimeout` appends survived refreshes, so a quick re-render could reappend stale items after the list was cleared. Now tracks and cancels pending timers before each render.
- **`messageHandler` restore path — 🟡 Minor:** only unhid `.message-expanded`, so a previously expanded row rendered both panes after a merge. Now hides `.message-collapsed` too.

## Tests
- Real-module tests for filter HTML-escaping + regex-special safety (verified they fail without the fix).
- Fake-timer test proving stale render timers are cancelled.
- Full suite: **462 passing**; ESLint, Prettier, `go build` clean.

These complete the #29 review — all 14 of its findings are now resolved (2 in #29, 7 in #32, 2 via #35/#36, 3 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Message highlighting now HTML-escapes message content and search terms before rendering, reducing the risk of unsafe HTML.
  * Highlighting still marks matched text and handles regex-special search terms as literal text.
* **Bug Fixes**
  * Prevented expanded and collapsed message panes from being shown simultaneously.
  * Resolved an issue where previously scheduled “Load More” queue items could appear after a full queue refresh.
* **Tests**
  * Added coverage for safe highlighting/escaping behavior and queue render timer cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->