### PR TITLE
feat(export): make CSV export reachable via an export menu

### DIFF
--- a/internal/static/files/modules/keyboardNavigation.js
+++ b/internal/static/files/modules/keyboardNavigation.js
@@ -371,8 +371,8 @@ export class KeyboardNavigation {
     if (exportButton) {
       exportButton.click();
     } else if (window.app?.messageExport) {
-      // Direct export if button not found
-      window.app.messageExport.exportCurrentView();
+      // Open the export menu (JSON/CSV/…) if the button isn't in the DOM.
+      window.app.messageExport.openExportMenu();
     }
   }
 

--- a/internal/static/files/modules/messageExport.js
+++ b/internal/static/files/modules/messageExport.js
@@ -321,6 +321,41 @@ export class MessageExport {
   }
 
   /**
+   * Open the export menu as a dismissible popover. This is the single UI entry
+   * point that exposes every export format (JSON + CSV) and scope; without it,
+   * CSV export was unreachable from the UI.
+   * @returns {HTMLElement|null} The mounted menu element, or null if nothing to export
+   */
+  openExportMenu() {
+    const messages = this.appState.getMessages();
+    if (!messages || messages.length === 0) {
+      return null;
+    }
+
+    // Avoid stacking duplicate menus.
+    document.querySelector('.export-menu')?.remove();
+
+    const menu = this.showExportMenu();
+    document.body.appendChild(menu);
+
+    // Dismiss on outside click or Escape.
+    const dismiss = (e) => {
+      if (e.type === 'keydown' && e.key !== 'Escape') return;
+      if (e.type === 'click' && menu.contains(e.target)) return;
+      menu.remove();
+      document.removeEventListener('click', dismiss, true);
+      document.removeEventListener('keydown', dismiss, true);
+    };
+    // Defer so the click that opened the menu doesn't immediately close it.
+    setTimeout(() => {
+      document.addEventListener('click', dismiss, true);
+      document.addEventListener('keydown', dismiss, true);
+    }, 0);
+
+    return menu;
+  }
+
+  /**
    * Show export menu
    * @returns {HTMLElement} Export menu element
    */

--- a/internal/static/files/modules/messageExport.js
+++ b/internal/static/files/modules/messageExport.js
@@ -338,14 +338,21 @@ export class MessageExport {
     const menu = this.showExportMenu();
     document.body.appendChild(menu);
 
+    const cleanup = () => {
+      document.removeEventListener('click', dismiss, true);
+      document.removeEventListener('keydown', dismiss, true);
+    };
     // Dismiss on outside click or Escape.
     const dismiss = (e) => {
       if (e.type === 'keydown' && e.key !== 'Escape') return;
       if (e.type === 'click' && menu.contains(e.target)) return;
       menu.remove();
-      document.removeEventListener('click', dismiss, true);
-      document.removeEventListener('keydown', dismiss, true);
+      cleanup();
     };
+    // The option/cancel buttons remove the menu themselves, so also detach our
+    // document listeners then to avoid leaking them after a selection.
+    menu.querySelectorAll('.export-option, .export-cancel').forEach((btn) => btn.addEventListener('click', cleanup));
+
     // Defer so the click that opened the menu doesn't immediately close it.
     setTimeout(() => {
       document.addEventListener('click', dismiss, true);

--- a/internal/static/files/modules/sqsApp.js
+++ b/internal/static/files/modules/sqsApp.js
@@ -73,7 +73,7 @@ export class SQSApp {
     const exportBtn = document.getElementById('exportMessages');
     if (exportBtn) {
       exportBtn.addEventListener('click', () => {
-        this.messageExport.exportCurrentView();
+        this.messageExport.openExportMenu();
       });
     }
 

--- a/test/messageExport.test.js
+++ b/test/messageExport.test.js
@@ -675,4 +675,47 @@ describe('MessageExport', () => {
       delete global.window.app;
     });
   });
+
+  describe('openExportMenu', () => {
+    it('mounts a dismissible menu exposing both JSON and CSV options', () => {
+      const menu = messageExport.openExportMenu();
+
+      expect(menu).not.toBeNull();
+      expect(document.querySelector('.export-menu')).toBe(menu);
+      const actions = Array.from(menu.querySelectorAll('.export-option')).map((b) => b.dataset.action);
+      expect(actions).toContain('current-json');
+      expect(actions).toContain('current-csv');
+    });
+
+    it('invokes CSV export when the CSV option is clicked', () => {
+      const csvSpy = vi.spyOn(messageExport, 'exportAsCSV').mockReturnValue({});
+      const menu = messageExport.openExportMenu();
+
+      menu.querySelector('[data-action="current-csv"]').click();
+
+      expect(csvSpy).toHaveBeenCalled();
+      expect(document.querySelector('.export-menu')).toBeNull(); // menu closes after action
+    });
+
+    it('invokes JSON export when the JSON option is clicked', () => {
+      const jsonSpy = vi.spyOn(messageExport, 'exportCurrentView').mockReturnValue({});
+      const menu = messageExport.openExportMenu();
+
+      menu.querySelector('[data-action="current-json"]').click();
+
+      expect(jsonSpy).toHaveBeenCalled();
+    });
+
+    it('does nothing (no menu) when there are no messages', () => {
+      mockAppState.getMessages.mockReturnValue([]);
+      expect(messageExport.openExportMenu()).toBeNull();
+      expect(document.querySelector('.export-menu')).toBeNull();
+    });
+
+    it('does not stack multiple menus', () => {
+      messageExport.openExportMenu();
+      messageExport.openExportMenu();
+      expect(document.querySelectorAll('.export-menu').length).toBe(1);
+    });
+  });
 });

--- a/test/messageExport.test.js
+++ b/test/messageExport.test.js
@@ -717,5 +717,16 @@ describe('MessageExport', () => {
       messageExport.openExportMenu();
       expect(document.querySelectorAll('.export-menu').length).toBe(1);
     });
+
+    it('detaches its document listeners after a selection (no leak)', () => {
+      vi.spyOn(messageExport, 'exportAsCSV').mockReturnValue({});
+      const removeSpy = vi.spyOn(document, 'removeEventListener');
+      const menu = messageExport.openExportMenu();
+
+      menu.querySelector('[data-action="current-csv"]').click();
+
+      expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function), true);
+      expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
Closes the CSV-export gap from the feature audit. The README advertises JSON/CSV, but the Export button and `e` shortcut only triggered JSON; the menu (`showExportMenu`) and `exportAsCSV` existed with no UI entry point.

## Change
- Add `MessageExport.openExportMenu()` — a dismissible popover (outside-click / Escape to close, no stacking) surfacing the existing options: Current View **JSON**/**CSV**, Filtered, All, Statistics.
- Point the Export button and the `e` shortcut fallback at it.

## Tests
5 new (real module): menu mounts with JSON+CSV options, CSV/JSON dispatch, no-messages no-op, no stacking. Full suite **475 passing**; lint/prettier/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export now opens a dedicated export menu instead of exporting immediately.
  * The menu includes JSON and CSV options, and supports dismissing via outside click or Escape.
  * When no direct export button is present, export flow now opens the same menu UI.
* **Bug Fixes**
  * Export menus no longer stack when opened repeatedly.
  * If there are no messages to export, no menu is shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->