### PR TITLE
docs: document existing features and the WS origin env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 ### 1. Test-Driven Development (TDD)
 
 - **ALWAYS** write tests before implementing new features
-- Maintain or improve the current test coverage (458 frontend + ~100 Go tests)
+- Maintain or improve the current test coverage (470+ frontend + ~110 Go tests)
 - Run both frontend (`npm test`) and backend (`go test ./...`) tests before committing
 - Each new module should have a corresponding test file
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ go build -o sqs-ui ./cmd/sqs-ui
 2. **No Framework**: Kept simple with vanilla JavaScript to minimize complexity and dependencies
 3. **Responsive Design**: CSS Grid and Flexbox for a modern, responsive layout
 4. **AWS-Inspired UI**: Design inspired by AWS Console and DataDog for familiar user experience
-5. **Comprehensive Testing**: 458 frontend tests using Vitest with full coverage of all modules
+5. **Comprehensive Testing**: 470+ frontend tests using Vitest with full coverage of all modules
 
 ### Goals
 
@@ -262,14 +262,14 @@ go build -o sqs-ui ./cmd/sqs-ui
 
 ## Testing
 
-The application includes comprehensive test coverage with 560+ tests across frontend (458 Vitest) and backend (Go).
+The application includes comprehensive test coverage with 580+ tests across frontend (470+ Vitest) and backend (Go).
 
 ### Frontend Tests
 
 Run the comprehensive JavaScript test suite:
 
 ```bash
-# Run all tests (458 tests)
+# Run all tests
 npm test
 
 # Run tests in watch mode during development

--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ A lightweight, web-based UI for managing AWS SQS queues built with Go and vanill
 - 📄 **Message Pagination**: Efficient browsing of large message sets
 - 🔍 **Smart Filtering**: Real-time search by content and attributes
 - ⌨️ **Keyboard Navigation**: Full keyboard shortcut support (press `?` for help)
-- 💾 **Export**: Download messages in JSON/CSV formats
+- 💾 **Export**: Download messages in JSON/CSV formats (via the Export menu)
 - 🖼️ **Queue Browser**: Full-screen message viewing modal
-- ✅ **Batch Operations**: Multi-select for bulk actions
+- ✅ **Batch Operations**: Multi-select for bulk delete/retry (retry shown for DLQs)
 - 🎭 **Demo Mode**: Fully functional demo without AWS credentials
+- 🌗 **Light/Dark Theme**: Toggle with auto-detection of your OS preference
+- ⏸️ **Pause/Resume Live Updates**: Freeze the WebSocket-driven message list while inspecting
+- 🔎 **Enhanced Message View**: JSON syntax highlighting, copy body/details, and receive-count badges
+- 🧭 **AWS Context Panel**: Shows the active mode (Demo/Live), region, profile, and account
 
 ## Prerequisites
 
@@ -162,6 +166,10 @@ make help
 - `FILTER_BUSINESS_UNIT` - Custom businessunit values (comma-separated)
 - `FILTER_PRODUCT` - Custom product values (comma-separated)
 - `FILTER_ENV` - Custom env values (comma-separated)
+
+#### Security
+
+- `ALLOWED_WEBSOCKET_ORIGINS` - Comma-separated allow-list of `Origin` headers accepted by the WebSocket endpoint (defaults to same-origin / localhost). Set this when serving the UI behind a non-localhost host.
 
 Example:
 


### PR DESCRIPTION
## Summary
Final gap from the feature audit — the README under-documented the app and a couple of claims needed clarifying now that the fixes (CSV export, DLQ retry) are merged.

## Changes
- **Added** feature bullets: light/dark theme (OS auto-detect), pause/resume live updates, enhanced message view (JSON highlighting, copy body/details, receive-count badges), AWS context panel.
- **Clarified**: Export is via a menu (JSON/CSV); batch retry is shown for DLQs — both now actually wired (#39, #40).
- **Documented** `ALLOWED_WEBSOCKET_ORIGINS` under a new Security config subsection (verified against `internal/websocket/websocket.go`).

Docs-only; Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the feature list to highlight more supported UI capabilities, including export options, batch actions, demo mode, theme switching, live-update controls, richer message views, and an AWS context panel.
  * Added WebSocket origin allow-list configuration guidance and refreshed the reported frontend test totals in the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->