### PR TITLE
ci: shorten critical path (build gating + Playwright cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,9 @@ jobs:
   build:
     name: Build Application
     runs-on: ubuntu-latest
-    needs: [lint-backend, lint-frontend, test-backend, test-frontend]
+    # Only gate the build on tests — lint runs in parallel and still gates the
+    # PR independently, so build need not wait for it.
+    needs: [test-backend, test-frontend]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -236,9 +238,23 @@ jobs:
           sleep 5
           curl -f http://localhost:8080 || exit 1
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-playwright-
+
       - name: Run E2E tests
         run: |
-          npx playwright install --with-deps chromium
+          # On a cache hit only the OS deps are installed (fast); the browser
+          # binary download is skipped.
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install --with-deps chromium
+          fi
           npm run test:e2e || true
 
   quality-gate:


### PR DESCRIPTION
## Summary
CI is parallel with a serial tail (`build` → `integration-test`). Two changes shorten the critical path; no coverage is dropped.

## Changes
- **`build` gates only on tests**, not lint. Lint still runs in parallel and independently gates the PR, so `build`/`integration-test` start as soon as tests pass instead of also waiting on lint.
- **Cache Playwright browsers** (`~/.cache/ms-playwright`) in `integration-test`. On a cache hit only OS deps install (`playwright install-deps`), skipping the chromium download — the slowest step on the critical path.

## Left as-is
`security-scan` (Trivy + gosec, ~1m20s) runs fully in parallel — off the critical path — so optimizing it would not change total time, and caching a container actions DB is flaky.

Net effect: `integration-test` starts sooner and runs faster on warm caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)