### PR TITLE
fix(local): non-locking ElasticMQ queues so the viewer shows messages

### DIFF
--- a/deploy/elasticmq.conf
+++ b/deploy/elasticmq.conf
@@ -18,20 +18,30 @@ rest-sqs {
   sqs-limits = strict
 }
 
+# defaultVisibilityTimeout = 0 makes the queues non-locking: the UI is a
+# read-only viewer that polls ReceiveMessage, so a normal timeout would hide
+# messages for 30s and the list would look empty. maxReceiveCount is high so
+# that repeated viewing doesn't redrive source messages into the DLQ.
 queues {
   demo-orders-queue {
+    defaultVisibilityTimeout = 0 seconds
     deadLettersQueue {
       name = "demo-orders-dlq"
-      maxReceiveCount = 3
+      maxReceiveCount = 1000
     }
   }
-  demo-orders-dlq { }
+  demo-orders-dlq {
+    defaultVisibilityTimeout = 0 seconds
+  }
 
   demo-notifications-queue {
+    defaultVisibilityTimeout = 0 seconds
     deadLettersQueue {
       name = "demo-notifications-dlq"
-      maxReceiveCount = 3
+      maxReceiveCount = 1000
     }
   }
-  demo-notifications-dlq { }
+  demo-notifications-dlq {
+    defaultVisibilityTimeout = 0 seconds
+  }
 }


### PR DESCRIPTION
## Problem
Against the local ElasticMQ, the sidebar showed a message count but the list was empty.

## Cause
The UI polls `ReceiveMessage` (list GET + WebSocket), which hides each received message for the queue visibility timeout (ElasticMQ default 30s). With continuous polling, every message stayed in-flight, so the list read empty.

The AWS SDK omits `VisibilityTimeout` when it is `0` (serializer guards on `!= 0`), so non-locking reads can't be forced from the request struct.

## Fix (config)
- `defaultVisibilityTimeout = 0 seconds` on the demo queues → receives no longer lock messages, so the viewer reliably shows them.
- `maxReceiveCount = 1000` → repeated viewing doesn't redrive source messages into the DLQ.

Verified: repeated message GETs now return content; visible counts orders=3 / notifications=2 / orders-dlq=2 / notifications-dlq=1, inflight=0.

Note: this is local dev tooling only. Viewing a *real* SQS queue still consumes visibility — inherent to SQS read semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local queue retry and dead-letter behavior for demo message flows.
  * Made queue timing settings explicit and increased retry attempts before messages move to dead-letter queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->